### PR TITLE
PLENTY-484-Export-error-plenty-bug

### DIFF
--- a/src/Response/Entity/Entity.php
+++ b/src/Response/Entity/Entity.php
@@ -77,9 +77,10 @@ abstract class Entity
             if ($shouldUseNestedProperties) {
                 $entityData = $entityData[self::NESTED_PROPERTIES[$field]];
             }
-            $entities[] = $this->getEntity($entityClass, $entityData, $key);
+            if (!is_null($entityData)) {
+                $entities[] = $this->getEntity($entityClass, $entityData, $key);
+            }
         }
-
         return $entities;
     }
 


### PR DESCRIPTION
The issue with the images in plenty. The image ID is present, while the image object is null.